### PR TITLE
Add: lens primitive sources, cylinder source

### DIFF
--- a/demos/optical_elements.py
+++ b/demos/optical_elements.py
@@ -1,0 +1,26 @@
+from raysect_mayavi import visualise_scenegraph
+
+from raysect.core import translate
+from raysect.optical import World
+from raysect.primitive import Cylinder
+from raysect.primitive.lens.spherical import BiConvex, BiConcave, PlanoConvex, PlanoConcave, Meniscus
+
+from mayavi import mlab
+# Display lens and cylinder primitives
+
+world = World()
+diameter = 1
+center_thickness = 0.5
+front_curvature = 2
+back_curvature = 2
+
+biconvex_lens = BiConvex(diameter, center_thickness, front_curvature, back_curvature, parent=world)
+biconcave_lens = BiConcave(diameter, center_thickness, front_curvature, back_curvature, parent=world, transform=translate(0, 0, 1))
+planoconvex_lens = PlanoConvex(diameter, center_thickness, front_curvature, parent=world, transform=translate(0, 0, 2))
+planoconcave_lens = PlanoConcave(diameter, center_thickness, front_curvature, parent=world, transform=translate(0, 0, 3))
+meniscus_lens = Meniscus(diameter, center_thickness, front_curvature, back_curvature, parent=world, transform=translate(0, 0, 4))
+cylinder_primitive = Cylinder(radius=0.5 * diameter, height=center_thickness, parent=world, transform=translate(0, 0, 5))
+
+
+visualise_scenegraph(world)
+mlab.show()

--- a/raysect_mayavi/primitives/geometric/__init__.py
+++ b/raysect_mayavi/primitives/geometric/__init__.py
@@ -1,0 +1,1 @@
+from .cylindrical import BiConvexLensSource, BiConcaveLensSource, PlanoConvexLensSource, PlanoConcaveLensSource, MeniscusLensSource, CylinderSource

--- a/raysect_mayavi/primitives/geometric/cylindrical.py
+++ b/raysect_mayavi/primitives/geometric/cylindrical.py
@@ -1,0 +1,433 @@
+from raysect_mayavi.primitives.source import SourceMesh
+from raysect_mayavi.primitives.geometric.utility import triangulate_open_cylinder, triangulate_cylinder_lid, triangulate_spherical_cap
+from raysect_mayavi.primitives.weld_vertices import weld_vertices
+
+from raysect.primitive import Mesh
+from raysect.primitive import Cylinder
+from raysect.primitive.lens.spherical import BiConvex, BiConcave, PlanoConvex, PlanoConcave, Meniscus
+
+import numpy as np
+from math import sqrt
+
+
+class CylindricalSource(SourceMesh):
+    """
+    Class for creting mesh sources for objects with cylindrical symmetry e.g. cylinder and lenses. The mesh is composed
+    of 3 surfaces: front surface, back surface and an open cylinder surface.
+    """
+
+    def __init__(self, raysect_primitive, vertical_divisions=10, cylindrical_divisions=36, radial_divisions=5):
+
+        self._barrel_vertices = None
+        self._barrel_triangles = None
+        self._front_vertices = None
+        self._front_triangles = None
+        self._back_vertices = None
+        self._back_triangles = None
+
+        self.vertical_divisions = vertical_divisions
+        self.cylindrical_divisions = cylindrical_divisions
+        self.radial_divisions = radial_divisions
+
+        super().__init__(raysect_primitive)
+
+    def _mesh_from_primitive(self):
+
+        # generate mesh parts if needed
+        if self._back_triangles is None or self._back_vertices is None:
+            self._generate_back_surface_mesh()
+        if self._barrel_triangles is None or self._barrel_vertices is None:
+            self._generate_barrel_surface_mesh()
+        if self._front_triangles is None or self._front_vertices is None:
+            self._generate_front_surface_mesh()
+
+        #combine vertices of the 3 surfaces
+        vertices = np.concatenate((self._back_vertices, self._barrel_vertices, self._front_vertices))
+
+        # recalculate and combine triangle ids for merged vertices
+        n_back = self._back_vertices.shape[0]
+        n_barrel = self._barrel_vertices.shape[0]
+
+        barrel_triangles = self._barrel_triangles.copy()
+        barrel_triangles += n_back
+        front_triangles = self._front_triangles.copy()
+        front_triangles += n_back + n_barrel
+
+        triangles = np.concatenate((self._back_triangles, barrel_triangles, front_triangles))
+
+        # create raysect mesh and weld duplicit vertices
+        mesh = Mesh(vertices=vertices, triangles=triangles)
+        self._raysect_mesh = weld_vertices(mesh)
+
+    def _generate_barrel_mesh(self):
+        """
+        Generates triangular mesh for the barrel surface.
+        :return:
+        """
+        raise NotImplementedError("Virtual method _generate_barrel_mesh() has not been implemented.")
+
+    def _generate_front_surface_mesh(self):
+        """
+        Generates triangular mesh for the front surface.
+        :return:
+        """
+        raise NotImplementedError("Virtual method _generate_front_surface_mesh() has not been implemented.")
+
+    def _generate_back_surface_mesh(self):
+        """
+        Generates triangular mesh for the back surface.
+        :return:
+        """
+        raise NotImplementedError("Virtual method _generate_back_surface_mesh() has not been implemented.")
+
+class CylinderSource(CylindricalSource):
+
+    def __init__(self, raysect_primitive, vertical_divisions=10, cylindrical_divisions=36, radial_divisions=5):
+
+        if not isinstance(raysect_primitive, Cylinder):
+            raise TypeError("raysect_primitive expected to be Cylinder instance")
+
+        super().__init__(raysect_primitive, vertical_divisions, cylindrical_divisions, radial_divisions)
+
+    def _generate_barrel_mesh(self):
+
+        radius = self.raysect_primitive.radius
+        height = self.raysect_primitive.height
+
+        vertices, triangles = triangulate_open_cylinder(radius, height, self.cylindrical_divisions,
+                                                        self.vertical_divisions)
+
+        self._barrel_vertices = vertices
+        self._barrel_triangles = triangles
+
+    def _generate_front_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = self.raysect_primitive.radius
+        edge = self._barrel_vertices[0:self.cylindrical_divisions, 0:2]
+
+        vertices, triangles = triangulate_cylinder_lid(radius, self.radial_divisions, edge_vertices=edge)
+
+        vertices[:, 2] = self.raysect_primitive.height
+
+        self._front_vertices = vertices
+        self._front_triangles = triangles
+
+    def _generate_back_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = self.raysect_primitive.radius
+        edge = self._barrel_vertices[0:self.cylindrical_divisions, 0:2]
+
+        vertices, triangles = triangulate_cylinder_lid(radius, self.radial_divisions, edge_vertices=edge)
+
+        self._back_vertices = vertices
+        self._back_triangles = triangles
+
+class BiConvexLensSource(CylindricalSource):
+
+    def __init__(self, raysect_primitive, vertical_divisions=10, cylindrical_divisions=36, radial_divisions=5):
+
+        if not isinstance(raysect_primitive, BiConvex):
+            raise TypeError("raysect_primitive expected to be BiConvex instance, but {} obtained".format(raysect_primitive))
+
+        super().__init__(raysect_primitive, vertical_divisions, cylindrical_divisions, radial_divisions)
+
+    def _generate_barrel_mesh(self):
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        height = self.raysect_primitive.edge_thickness
+
+        vertices, triangles = triangulate_open_cylinder(radius, height, self.cylindrical_divisions,
+                                                        self.vertical_divisions)
+
+        # shift cylinder vertices z coordinate
+        vertices[:, 2] += self.raysect_primitive.back_thickness
+
+        self._barrel_vertices = vertices
+        self._barrel_triangles = triangles
+
+    def _generate_front_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[-self.cylindrical_divisions::, 0:2]
+        z_center = self.raysect_primitive.center_thickness - self.raysect_primitive.front_curvature
+        curvature = self.raysect_primitive.front_curvature
+
+        vertices, triangles = triangulate_spherical_cap(curvature, radius,
+                                                        self.radial_divisions, edge_vertices=edge)
+
+        for i, v in enumerate(vertices):
+            r2 = v[0] ** 2 + v[1] ** 2
+            z = z_center + sqrt(curvature ** 2 - r2)
+            vertices[i, 2] = z
+
+        self._front_vertices = vertices
+        self._front_triangles = triangles
+
+    def _generate_back_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[0:self.cylindrical_divisions, 0:2]
+        z_center = self.raysect_primitive.back_curvature
+        curvature = self.raysect_primitive.back_curvature
+
+        vertices, triangles = triangulate_spherical_cap(curvature, radius, self.radial_divisions, edge_vertices=edge)
+
+        for i, v in enumerate(vertices):
+            r2 = v[0] ** 2 + v[1] ** 2
+            z = z_center - sqrt(curvature ** 2 - r2)
+            vertices[i, 2] = z
+
+        self._back_vertices = vertices
+        self._back_triangles = triangles
+
+
+class BiConcaveLensSource(CylindricalSource):
+
+    def __init__(self, raysect_primitive, vertical_divisions=10, cylindrical_divisions=36, radial_divisions=5):
+
+        if not isinstance(raysect_primitive, BiConcave):
+            raise TypeError("raysect_primitive expected to be BiConcave instance, but {} obtained".format(raysect_primitive))
+
+        super().__init__(raysect_primitive, vertical_divisions, cylindrical_divisions, radial_divisions)
+
+    def _generate_barrel_mesh(self):
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        height = self.raysect_primitive.edge_thickness
+
+        vertices, triangles = triangulate_open_cylinder(radius, height, self.cylindrical_divisions,
+                                                        self.vertical_divisions)
+
+        # shift cylinder vertices z coordinate
+        vertices[:, 2] -= self.raysect_primitive.back_thickness
+
+        self._barrel_vertices = vertices
+        self._barrel_triangles = triangles
+
+    def _generate_front_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[-self.cylindrical_divisions::, 0:2]
+        z_center = self.raysect_primitive.center_thickness + self.raysect_primitive.front_curvature
+        curvature = self.raysect_primitive.front_curvature
+
+        vertices, triangles = triangulate_spherical_cap(curvature, radius,
+                                                        self.radial_divisions, edge_vertices=edge)
+
+        for i, v in enumerate(vertices):
+            r2 = v[0] ** 2 + v[1] ** 2
+            z = z_center - sqrt(curvature ** 2 - r2)
+            vertices[i, 2] = z
+
+        self._front_vertices = vertices
+        self._front_triangles = triangles
+
+    def _generate_back_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[0:self.cylindrical_divisions, 0:2]
+        z_center = -self.raysect_primitive.back_curvature
+        curvature = self.raysect_primitive.back_curvature
+
+        vertices, triangles = triangulate_spherical_cap(curvature, radius, self.radial_divisions, edge_vertices=edge)
+
+        for i, v in enumerate(vertices):
+            r2 = v[0] ** 2 + v[1] ** 2
+            z = z_center + sqrt(curvature ** 2 - r2)
+            vertices[i, 2] = z
+
+        self._back_vertices = vertices
+        self._back_triangles = triangles
+
+
+class PlanoConvexLensSource(CylindricalSource):
+
+    def __init__(self, raysect_primitive, vertical_divisions=10, cylindrical_divisions=36, radial_divisions=5):
+
+        if not isinstance(raysect_primitive, PlanoConvex):
+            raise TypeError("raysect_primitive expected to be BiConvex instance")
+
+        super().__init__(raysect_primitive, vertical_divisions, cylindrical_divisions, radial_divisions)
+
+    def _generate_barrel_mesh(self):
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        height = self.raysect_primitive.edge_thickness
+
+        vertices, triangles = triangulate_open_cylinder(radius, height, self.cylindrical_divisions,
+                                                        self.vertical_divisions)
+
+        self._barrel_vertices = vertices
+        self._barrel_triangles = triangles
+
+    def _generate_front_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[-self.cylindrical_divisions::, 0:2]
+        z_center = self.raysect_primitive.center_thickness - self.raysect_primitive.curvature
+        curvature = self.raysect_primitive.curvature
+
+        vertices, triangles = triangulate_spherical_cap(curvature, radius,
+                                                        self.radial_divisions, edge_vertices=edge)
+
+        for i, v in enumerate(vertices):
+            r2 = v[0] ** 2 + v[1] ** 2
+            z = z_center + sqrt(curvature ** 2 - r2)
+            vertices[i, 2] = z
+
+        self._front_vertices = vertices
+        self._front_triangles = triangles
+
+    def _generate_back_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[0:self.cylindrical_divisions, 0:2]
+
+        vertices, triangles = triangulate_cylinder_lid(radius, self.radial_divisions, edge_vertices=edge)
+
+        self._back_vertices = vertices
+        self._back_triangles = triangles
+
+
+class PlanoConcaveLensSource(CylindricalSource):
+
+    def __init__(self, raysect_primitive, vertical_divisions=10, cylindrical_divisions=36, radial_divisions=5):
+
+        if not isinstance(raysect_primitive, PlanoConcave):
+            raise TypeError("raysect_primitive expected to be PlanoConcave instance")
+
+        super().__init__(raysect_primitive, vertical_divisions, cylindrical_divisions, radial_divisions)
+
+    def _generate_barrel_mesh(self):
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        height = self.raysect_primitive.edge_thickness
+
+        vertices, triangles = triangulate_open_cylinder(radius, height, self.cylindrical_divisions,
+                                                        self.vertical_divisions)
+
+        self._barrel_vertices = vertices
+        self._barrel_triangles = triangles
+
+    def _generate_front_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[-self.cylindrical_divisions::, 0:2]
+        z_center = self.raysect_primitive.center_thickness + self.raysect_primitive.curvature
+        curvature = self.raysect_primitive.curvature
+
+        vertices, triangles = triangulate_spherical_cap(curvature, radius,
+                                                        self.radial_divisions, edge_vertices=edge)
+
+        for i, v in enumerate(vertices):
+            r2 = v[0] ** 2 + v[1] ** 2
+            z = z_center - sqrt(curvature ** 2 - r2)
+            vertices[i, 2] = z
+
+        self._front_vertices = vertices
+        self._front_triangles = triangles
+
+    def _generate_back_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[0:self.cylindrical_divisions, 0:2]
+
+        vertices, triangles = triangulate_cylinder_lid(radius, self.radial_divisions, edge_vertices=edge)
+
+        self._back_vertices = vertices
+        self._back_triangles = triangles
+
+
+class MeniscusLensSource(CylindricalSource):
+
+    def __init__(self, raysect_primitive, vertical_divisions=10, cylindrical_divisions=36, radial_divisions=5):
+
+        if not isinstance(raysect_primitive, Meniscus):
+            raise TypeError("raysect_primitive expected to be Meniscus instance")
+
+        super().__init__(raysect_primitive, vertical_divisions, cylindrical_divisions, radial_divisions)
+
+    def _generate_barrel_mesh(self):
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        height = self.raysect_primitive.edge_thickness
+
+        vertices, triangles = triangulate_open_cylinder(radius, height, self.cylindrical_divisions,
+                                                        self.vertical_divisions)
+
+        # shift cylinder vertices z coordinate
+        vertices[:, 2] -= self.raysect_primitive.back_thickness
+
+        self._barrel_vertices = vertices
+        self._barrel_triangles = triangles
+
+    def _generate_front_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[-self.cylindrical_divisions::, 0:2]
+        z_center = self.raysect_primitive.center_thickness - self.raysect_primitive.front_curvature
+        curvature = self.raysect_primitive.front_curvature
+
+        vertices, triangles = triangulate_spherical_cap(curvature, radius,
+                                                        self.radial_divisions, edge_vertices=edge)
+
+        for i, v in enumerate(vertices):
+            r2 = v[0] ** 2 + v[1] ** 2
+            z = z_center + sqrt(curvature ** 2 - r2)
+            vertices[i, 2] = z
+
+        self._front_vertices = vertices
+        self._front_triangles = triangles
+
+    def _generate_back_surface_mesh(self):
+
+        if self._barrel_vertices is None or self._barrel_triangles is None:
+            self._generate_barrel_mesh()
+
+        radius = 0.5 * self.raysect_primitive.diameter
+        edge = self._barrel_vertices[0:self.cylindrical_divisions, 0:2]
+        z_center = -self.raysect_primitive.back_curvature
+        curvature = self.raysect_primitive.back_curvature
+
+        vertices, triangles = triangulate_spherical_cap(curvature, radius, self.radial_divisions, edge_vertices=edge)
+
+        for i, v in enumerate(vertices):
+            r2 = v[0] ** 2 + v[1] ** 2
+            z = z_center + sqrt(curvature ** 2 - r2)
+            vertices[i, 2] = z
+
+        self._back_vertices = vertices
+        self._back_triangles = triangles

--- a/raysect_mayavi/primitives/geometric/utility.py
+++ b/raysect_mayavi/primitives/geometric/utility.py
@@ -1,0 +1,148 @@
+import numpy as np
+
+from math import sqrt
+
+from scipy.spatial import Delaunay
+
+
+def triangulate_circle(radius, radial_divisions=10, edge_vertices=None, cylindrical_divisions=90):
+    """
+    Meshes a cirlcle using scipy.spatial.Delaunay. Mesh vertices are generated on co-centric circles.
+    :param radius: Radius of the circle to mesh
+    :param radial_divisions: Sets the number of co-centric sub-circles the circle is separated into and
+                              vertices are placed at.
+    :param edge_vertices: 2D coordinates (x, y) of vertices on the outer-most circle to be used. This is useful if the
+                           generated mesh is supposed to be combined with some other mesh parts to generate a more
+                           complicated mesh object.
+    :param cylindrical_divisions: Number of vertices the outer-most circle will be divided in. Is ignored if
+                                   outer_vertices is passed.
+    :return: tupple (vertices, triangles) where vertices and triangles are 2D numpy arrays with vertex coordinates and
+             triangle vertex ids, respectively.
+    """
+    if edge_vertices is not None:
+        vertices = edge_vertices.tolist()
+        cylindrical_divisions = len(edge_vertices)
+        working_cylindrical_segments = cylindrical_divisions - int(cylindrical_divisions / (radial_divisions + 1))
+        segment_start = 1
+    else:
+        working_cylindrical_segments = cylindrical_divisions
+        vertices = []
+        segment_start = 0
+
+    for i in range(segment_start, radial_divisions):
+
+        working_radius = radius * (1 - (i / radial_divisions))
+        theta_step = 360 / working_cylindrical_segments
+
+        for j in range(working_cylindrical_segments):
+            theta_rad = np.deg2rad(j * theta_step)
+            vertices.append([working_radius * np.cos(theta_rad), working_radius * np.sin(theta_rad)])
+
+        working_cylindrical_segments -= int(cylindrical_divisions / (radial_divisions + 1))
+        if working_cylindrical_segments < 5:
+            working_cylindrical_segments = 5
+    # Finally, add centre point and convert to numpy array
+    vertices.append([0, 0])
+    vertices = np.array(vertices)
+
+    triangles = Delaunay(vertices).simplices
+
+    return vertices, triangles
+
+
+def triangulate_open_cylinder(radius, height, cylindrical_divisions=90, vertical_divisions=10):
+    """
+    Generates a 3D mesh of an opene cylinder. The cylindrer axis as aligned with the z axis and extends from z=0 to
+    z=height.
+    :param cylindrical_divisions: Number of cylindrical division of the barrel the vertices will be generated on.
+    :param vertical_divisions: Number of vertical levels vertices will be generated on.
+    :param radius: Radius of the barrel.
+    :param height: Height of the barrel.
+    :return: tupple (vertices, triangles) where vertices is a 2D numpy array with 3D (Mx3) vertex coorditanes. The
+             triangles is a 2D numpy array with triangle vertex ids.
+    """
+    theta_step = 360 / cylindrical_divisions
+
+    vertices = []
+    for i in range(vertical_divisions):
+        z = (i / (vertical_divisions - 1)) * height
+        for j in range(cylindrical_divisions):
+            theta_rad = np.deg2rad(j * theta_step)
+            vertices.append([radius * np.cos(theta_rad), radius * np.sin(theta_rad), z])
+
+    triangles = []
+    for i in range(vertical_divisions - 1):
+
+        row_start = cylindrical_divisions * i
+        next_row_start = cylindrical_divisions * (i + 1)
+
+        for j in range(cylindrical_divisions):
+
+            v1 = row_start + j
+            if j != cylindrical_divisions - 1:
+                v2 = row_start + j + 1
+                v3 = next_row_start + j + 1
+            else:
+                v2 = row_start
+                v3 = next_row_start
+            v4 = next_row_start + j
+
+            triangles.append([v1, v2, v3])
+            triangles.append([v3, v4, v1])
+
+    # convert to numpy arrays
+    vertices = np.array(vertices)
+    triangles = np.array(triangles)
+
+    return vertices, triangles
+
+
+def triangulate_cylinder_lid(radius, radial_divisions, edge_vertices=None, cylindrical_divisions=90):
+    """
+
+    :param radial_divisions:
+    :param radius:
+    :param z_height:
+    :param edge_vertices:
+    :return:
+    """
+
+    circle_vertices, triangles =triangulate_circle(radius, radial_divisions, edge_vertices=edge_vertices,
+                                                   cylindrical_divisions=cylindrical_divisions)
+
+    vertices = np.zeros((circle_vertices.shape[0], 3))
+    vertices[:, 0:-1] = circle_vertices
+
+    return vertices, triangles
+
+
+def triangulate_spherical_cap(sphere_radius, base_radius, radial_divisions, edge_vertices=None, cylindrical_divisions=90):
+    """
+    Triangulate a spherical cap without the base with axis of symmetry aligned with the z axis and the sphere center at
+    z=0. The cap is located in the positive z half-plane.
+    :param sphere_radius: Radius of the sphere
+    :param base_radius: The radius of the cap base
+    :param radial_divisions: Number of radial segments to place vertices at
+    :param edge_vertices: Gives the edge vertex positions (x, y). This is useful if the cap edge points should be identical to
+                          other meshes which simplifies welding of meshes.
+    :return: tupple (vertices, triangles) where vertices is a 2D numpy array with 3D (Mx3) vertex coorditanes. The
+             triangles is a 2D numpy array with triangle vertex ids.
+    """""
+
+    circle_vertices, triangles = triangulate_circle(base_radius, radial_divisions, edge_vertices=edge_vertices,
+                                                    cylindrical_divisions=cylindrical_divisions)
+
+    # lift circle vertices to form the 3D surface
+    vertices = np.zeros((circle_vertices.shape[0], 3))
+    vertices[:, 0:-1] = circle_vertices
+    sr2 = sphere_radius ** 2
+    for i, v in enumerate(vertices):
+        r2 = v[0] ** 2 + v[1] ** 2
+        z = sqrt(sr2 - r2)
+        vertices[i, -1] = z
+
+
+    return vertices, triangles
+
+def triangulate_parabolic_cap():
+    pass

--- a/raysect_mayavi/primitives/source.py
+++ b/raysect_mayavi/primitives/source.py
@@ -1,0 +1,62 @@
+from raysect.core import Point3D
+from raysect.primitive import Mesh
+
+class SourceMesh:
+
+    def __init__(self, raysect_primitive):
+
+        self._raysect_primitive = raysect_primitive
+        self._raysect_mesh = None
+
+        self._mesh_from_primitive()
+
+    def _vertices_transform(self):
+        vertices = self._raysect_mesh.data.vertices.copy()
+
+        if self._raysect_primitive.parent:
+            to_world = self._raysect_primitive.to_root()
+        else:
+            to_world = self._raysect_primitive.transform
+
+        for i in range(vertices.shape[0]):
+            p = Point3D(vertices[i, 0], vertices[i, 1], vertices[i, 2]).transform(to_world)
+            vertices[i, 0] = p.x
+            vertices[i, 1] = p.y
+            vertices[i, 2] = p.z
+
+        return vertices
+
+    @property
+    def raysect_primitive(self):
+        return self._raysect_primitive
+
+    @property
+    def vertices_local(self):
+        return self._raysect_mesh.data.vertices()
+
+    @property
+    def vertices(self):
+        return self._vertices_transform()
+
+    @property
+    def vertices_x(self):
+        return self._vertices_transform()[:, 0]
+
+    @property
+    def vertices_y(self):
+        return self._vertices_transform()[:, 1]
+
+    @property
+    def vertices_z(self):
+        return self._vertices_transform()[:, 2]
+
+    @property
+    def triangles(self):
+        return self._raysect_mesh.data.triangles
+
+    def _mesh_from_primitive(self):
+        """
+        Constructs raysect Mesh from sources.
+        :return:
+        """
+        raise NotImplementedError("Virtual method _mesh_from_primitive() has not been implemented.")


### PR DESCRIPTION
Class for mesh sources added.

Class for objects with cylindrical shape added. Treats objects which have 2 faces (front and back) and an empty cylinder connecting them.

Classes generating mesh sources for shperical lenses added.

changes in raysect_mayavi/primitives/to_mesh.py:
	Functions returning triangles and vertices for lens objects added. They are factory functions creating corresponding lens objects calculating the mesh.
	Same approach taken for the Cylinder object.

Added example with lenses.